### PR TITLE
Fixed not handling additional SSL options

### DIFF
--- a/source/utils/connection/index.ts
+++ b/source/utils/connection/index.ts
@@ -12,6 +12,21 @@ async function getMongoConnectionOptions(options: ConnectionOptions): Promise<Mo
     if (options.ssl) {
         result.ssl = options.ssl;
     }
+    if (options.sslCAFile) {
+        result.tlsCAFile = options.sslCAFile;
+    }
+    if (options.sslAllowInvalidCertificates) {
+        result.tlsAllowInvalidCertificates = options.sslAllowInvalidCertificates;
+    }
+    if (options.sslAllowInvalidHostnames) {
+        result.tlsAllowInvalidHostnames = options.sslAllowInvalidHostnames;
+    }
+    if (options.sslPEMKeyPassword) {
+        result.tlsCertificateKeyFilePassword = options.sslPEMKeyPassword;
+    }
+    if (options.sslPEMKeyFile) {
+        result.tlsCertificateKeyFile = options.sslPEMKeyFile;
+    }
 
     return result;
 }

--- a/source/utils/exportCollections/getCommand.ts
+++ b/source/utils/exportCollections/getCommand.ts
@@ -31,7 +31,7 @@ function parseUri(options: ConnectionOptions, db: string): string {
     let result = '';
 
     if (options.uri) {
-        const lastSlash = options.uri.lastIndexOf('/');
+        const lastSlash = options.uri.split('?')[0].lastIndexOf('/');
         const protocolSlash = options.uri.indexOf('//') + 1;
         const dbSlash = lastSlash > protocolSlash ? lastSlash : -1;
         if (dbSlash === -1) {
@@ -40,7 +40,7 @@ function parseUri(options: ConnectionOptions, db: string): string {
             const pre = options.uri.slice(0, dbSlash);
             const optionsIndex = options.uri.indexOf('?');
             const post = optionsIndex === -1 ? '' : options.uri.slice(optionsIndex);
-            result = ` --uri=${pre}/${db}${post}`;
+            result = ` --uri="${pre}/${db}${post}"`;
         }
     }
 

--- a/source/utils/exportCollections/getCommand.ts
+++ b/source/utils/exportCollections/getCommand.ts
@@ -35,7 +35,7 @@ function parseUri(options: ConnectionOptions, db: string): string {
         const protocolSlash = options.uri.indexOf('//') + 1;
         const dbSlash = lastSlash > protocolSlash ? lastSlash : -1;
         if (dbSlash === -1) {
-            result = ` --uri=${options.uri}/${db}`;
+            result = ` --uri="${options.uri}/${db}"`;
         } else {
             const pre = options.uri.slice(0, dbSlash);
             const optionsIndex = options.uri.indexOf('?');

--- a/test/getCommand/getCommand.test.ts
+++ b/test/getCommand/getCommand.test.ts
@@ -15,7 +15,7 @@ export default function (): void {
             };
             const outPath = './exported';
 
-            const expected = 'mongoexport --uri=mongodb://localhost:27017/cars --collection=Ferrari --out=./exported';
+            const expected = 'mongoexport --uri="mongodb://localhost:27017/cars" --collection=Ferrari --out=./exported';
             const result = getCommand(database, collection, options, outPath);
             expect(result).to.equal(expected);
         });
@@ -30,7 +30,7 @@ export default function (): void {
             };
             const outPath = './exported';
 
-            const expected = 'mongoexport --uri=mongodb://localhost:27017/cars --collection=Ferrari --out=./exported';
+            const expected = 'mongoexport --uri="mongodb://localhost:27017/cars" --collection=Ferrari --out=./exported';
             const result = getCommand(database, collection, options, outPath);
             expect(result).to.equal(expected);
         });
@@ -46,7 +46,24 @@ export default function (): void {
             const outPath = './exported';
 
             const expected =
-                'mongoexport --uri=mongodb://localhost:27017/cars?connectTimeoutMS=300000 --collection=Ferrari --out=./exported';
+                'mongoexport --uri="mongodb://localhost:27017/cars?connectTimeoutMS=300000" --collection=Ferrari --out=./exported';
+            const result = getCommand(database, collection, options, outPath);
+            expect(result).to.equal(expected);
+        });
+
+        it(`Should return a command with a correctly parsed uri with additional parameters and slash paths`, function () {
+            const database = 'cars';
+            const collection: ExportingCollection = {
+                name: 'Ferrari'
+            };
+            const options: ConnectionOptions = {
+                uri:
+                    'mongodb://localhost:27017/computers?connectTimeoutMS=300000&authSource=admin&tls=true&tlsCAFile=./secret/ca.txt'
+            };
+            const outPath = './exported';
+
+            const expected =
+                'mongoexport --uri="mongodb://localhost:27017/cars?connectTimeoutMS=300000&authSource=admin&tls=true&tlsCAFile=./secret/ca.txt" --collection=Ferrari --out=./exported';
             const result = getCommand(database, collection, options, outPath);
             expect(result).to.equal(expected);
         });

--- a/test/getMongoConnection/getMongoConnection.test.ts
+++ b/test/getMongoConnection/getMongoConnection.test.ts
@@ -134,5 +134,29 @@ export default function (): void {
             const result = await getMongoConnectionFromOptions(options);
             expect(result.uri).to.equal(expected);
         });
+
+        it(`Should return a uri and correct ssl configuration`, async function () {
+            const options: ConnectionOptions = {
+                host: 'localhost',
+                port: 27017,
+                authenticationDatabase: 'users',
+                authenticationMechanism: AuthenticationMechanism.PLAIN,
+                ssl: true,
+                sslCAFile: './cert/ca.pem',
+                sslAllowInvalidCertificates: true,
+                sslAllowInvalidHostnames: true
+            };
+
+            const expected = 'mongodb://localhost:27017/?authSource=users&authMechanism=PLAIN';
+            const expectedOptions = {
+                ssl: true,
+                tlsAllowInvalidCertificates: true,
+                tlsAllowInvalidHostnames: true,
+                tlsCAFile: './cert/ca.pem'
+            };
+            const result = await getMongoConnectionFromOptions(options);
+            expect(result.uri).to.equal(expected);
+            expect(result.options).to.deep.equal(expectedOptions);
+        });
     });
 }


### PR DESCRIPTION
**File:** `source/utils/connection/index.ts`
Additional SSL options like sslCAFile, sslAllowInvalidCertificates, and others were not being passed to MongoScanner, resulting in MongoScanner failing to connect to the database, even though you set these options in the main config of MongoBack.

**File:** `source/utils/exportCollections/getCommand.ts`
When using uri string which contains slashes and additional parameters, the export was failing due to incorrectly parsing the uri string.
_Example: mongodb://127.0.0.1:27017/test-db?authSource=admin&replicaSet=test-db-set&tls=true&tlsCAFile=./.cert/sslCA.txt_
Additionally, added double quotes around the `--uri` option to correctly pass the uri string if it contains symbols like `&` which would break the mongoexport command otherwise.