### PR TITLE
Mongo dump

### DIFF
--- a/source/errors/index.ts
+++ b/source/errors/index.ts
@@ -3,3 +3,4 @@ export * from './mongoBackError';
 export * from './databaseError';
 export * from './exportingError';
 export * from './mongoexportNotInstalledError';
+export * from './mongodumpNotInstalledError';

--- a/source/errors/mongodumpNotInstalledError.ts
+++ b/source/errors/mongodumpNotInstalledError.ts
@@ -1,0 +1,18 @@
+import { MongoBackError } from './mongoBackError';
+
+/**
+ * The MongoBackError that happens because mongodump is not installed
+ */
+export class MongodumpNotInstalledError extends MongoBackError {
+    private static readonly DEFAULT_MESSAGE = 'Mongodump is not installed';
+    /**
+     * The error that triggered the problem
+     */
+    public triggerError: Error | null;
+
+    constructor(message?: string, triggerError?: Error) {
+        super(message ?? MongodumpNotInstalledError.DEFAULT_MESSAGE);
+        this.name = 'MongoBackMongodumpNotInstalledError';
+        this.triggerError = triggerError ?? null;
+    }
+}

--- a/source/index.ts
+++ b/source/index.ts
@@ -11,6 +11,7 @@ import { mergeOptions } from '@/utils/options';
 import { getParsedCollections, removeSchemaDetails } from '@/utils/getParsedCollections';
 import { exportCollections } from '@/utils/exportCollections';
 import { getMongoConnectionFromOptions } from '@/utils/connection';
+import { checkMongodumpInstalled } from './utils/checkMongodumpInstalled';
 
 /**
  * The function to export collections from a mongodb. You can specify the mongodb collection,
@@ -18,8 +19,12 @@ import { getMongoConnectionFromOptions } from '@/utils/connection';
  * @param options The options to specify how, where and what will be exported.
  */
 export async function mongoExport(options?: Options): Promise<ExportResult> {
-    // Check that mongoexport is installed
-    checkMongoexportInstalled();
+    // Check that mongoexport/mongodump is installed
+    if (options?.method === 'mongodump') {
+        checkMongodumpInstalled();
+    } else {
+        checkMongoexportInstalled();
+    }
     // Get purged options
     options = mergeOptions(options);
     // Instantiate logger util

--- a/source/interfaces/options/configOptions/index.ts
+++ b/source/interfaces/options/configOptions/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Various config options
+ */
+export interface ConfigOptions {
+    /**
+     * The backup method to use.
+     *
+     * Possible values:
+     * - 'mongoexport': During exporting, mongoexport command will be used
+     * - 'mongodump': During exporting, mongodump command will be used
+     *
+     * Default: 'mongoexport'
+     */
+    method?: 'mongoexport' | 'mongodump';
+}

--- a/source/interfaces/options/index.ts
+++ b/source/interfaces/options/index.ts
@@ -4,6 +4,7 @@ export * from './exportingOptions';
 export * from './logOptions';
 export * from './outOptions';
 
+import { ConfigOptions } from './configOptions';
 import { ConnectionOptions } from './connectionOptions';
 import { ExportedOptions } from './exportedOptions';
 import { ExportingOptions } from './exportingOptions';
@@ -27,4 +28,4 @@ import { OutOptions } from './outOptions';
  * @see {@link https://docs.mongodb.com/manual/reference/program/mongoexport/} to further
  * information on the mongoexport options.
  */
-export type Options = ConnectionOptions & ExportedOptions & ExportingOptions & LogOptions & OutOptions;
+export type Options = ConnectionOptions & ExportedOptions & ExportingOptions & LogOptions & OutOptions & ConfigOptions;

--- a/source/utils.helper.ts
+++ b/source/utils.helper.ts
@@ -1,4 +1,5 @@
 export * from '@/utils/checkMongoexportInstalled';
+export * from '@/utils/checkMongodumpInstalled';
 export * from '@/utils/connection';
 export * from '@/utils/exportCollections';
 export * from '@/utils/getParsedCollections';

--- a/source/utils/bin/index.ts
+++ b/source/utils/bin/index.ts
@@ -2,6 +2,7 @@ import { Options } from '@/interfaces/options';
 import { CliOptions } from '@/interfaces/bin';
 
 import { checkMongoexportInstalled } from '@/utils/checkMongoexportInstalled';
+import { checkMongodumpInstalled } from '../checkMongodumpInstalled';
 import { mergeOptions } from '@/utils/options';
 import { Logger } from '@/utils/logger';
 import { getMongoConnectionFromOptions } from '@/utils/connection';
@@ -13,8 +14,12 @@ import { askDestination } from './askDestination';
 import { askCollections } from './askCollections';
 
 export async function mongoExportCli(options: Options, cliOptions: CliOptions): Promise<void> {
-    // Check that mongoexport is installed
-    checkMongoexportInstalled();
+    // Check that mongoexport/mongodump is installed
+    if (options.method === 'mongodump') {
+        checkMongodumpInstalled();
+    } else {
+        checkMongoexportInstalled();
+    }
     // Get purged options
     options = mergeOptions(options);
     // Instantiate logger util

--- a/source/utils/checkMongodumpInstalled/index.ts
+++ b/source/utils/checkMongodumpInstalled/index.ts
@@ -1,0 +1,12 @@
+import { sync as commandExists } from 'command-exists';
+import { MongodumpNotInstalledError } from '@/errors';
+
+function mongodumpInstalled(): boolean {
+    return commandExists('mongodump');
+}
+
+export function checkMongodumpInstalled(): void {
+    if (!mongodumpInstalled()) {
+        throw new MongodumpNotInstalledError();
+    }
+}

--- a/source/utils/connection/index.ts
+++ b/source/utils/connection/index.ts
@@ -12,6 +12,21 @@ async function getMongoConnectionOptions(options: ConnectionOptions): Promise<Mo
     if (options.ssl) {
         result.ssl = options.ssl;
     }
+    if (options.sslCAFile) {
+        result.tlsCAFile = options.sslCAFile;
+    }
+    if (options.sslAllowInvalidCertificates) {
+        result.tlsAllowInvalidCertificates = options.sslAllowInvalidCertificates;
+    }
+    if (options.sslAllowInvalidHostnames) {
+        result.tlsAllowInvalidHostnames = options.sslAllowInvalidHostnames;
+    }
+    if (options.sslPEMKeyPassword) {
+        result.tlsCertificateKeyFilePassword = options.sslPEMKeyPassword;
+    }
+    if (options.sslPEMKeyFile) {
+        result.tlsCertificateKeyFile = options.sslPEMKeyFile;
+    }
 
     return result;
 }

--- a/source/utils/exportCollections/getCommand.ts
+++ b/source/utils/exportCollections/getCommand.ts
@@ -31,7 +31,7 @@ function parseUri(options: ConnectionOptions, db: string): string {
     let result = '';
 
     if (options.uri) {
-        const lastSlash = options.uri.lastIndexOf('/');
+        const lastSlash = options.uri.split('?')[0].lastIndexOf('/');
         const protocolSlash = options.uri.indexOf('//') + 1;
         const dbSlash = lastSlash > protocolSlash ? lastSlash : -1;
         if (dbSlash === -1) {
@@ -40,7 +40,7 @@ function parseUri(options: ConnectionOptions, db: string): string {
             const pre = options.uri.slice(0, dbSlash);
             const optionsIndex = options.uri.indexOf('?');
             const post = optionsIndex === -1 ? '' : options.uri.slice(optionsIndex);
-            result = ` --uri=${pre}/${db}${post}`;
+            result = ` --uri="${pre}/${db}${post}"`;
         }
     }
 

--- a/source/utils/exportCollections/getCommand.ts
+++ b/source/utils/exportCollections/getCommand.ts
@@ -35,7 +35,7 @@ function parseUri(options: ConnectionOptions, db: string): string {
         const protocolSlash = options.uri.indexOf('//') + 1;
         const dbSlash = lastSlash > protocolSlash ? lastSlash : -1;
         if (dbSlash === -1) {
-            result = ` --uri=${options.uri}/${db}`;
+            result = ` --uri="${options.uri}/${db}"`;
         } else {
             const pre = options.uri.slice(0, dbSlash);
             const optionsIndex = options.uri.indexOf('?');

--- a/source/utils/exportCollections/getCommand.ts
+++ b/source/utils/exportCollections/getCommand.ts
@@ -1,5 +1,5 @@
 import { ExportingCollection } from '@/interfaces/result';
-import { ConnectionOptions, ExportingOptions } from '@/interfaces/options';
+import { ConnectionOptions, ExportingOptions, Options } from '@/interfaces/options';
 
 function parseGenericBoolean(options: ConnectionOptions | ExportingOptions, param: string): string {
     return options[param] ? ` --${param}` : '';
@@ -96,9 +96,11 @@ function parseFields(options: ExportingOptions): string {
 export function getCommand(
     database: string,
     parsedCollection: ExportingCollection,
-    options: ConnectionOptions,
+    options: Options,
     outPath: string
 ): string {
+    const method = options.method ?? 'mongoexport';
+
     const db = options.uri ? '' : ` --db=${database}`;
     const collection = ` --collection=${parsedCollection.name}`;
 
@@ -143,6 +145,6 @@ export function getCommand(
 
     const out = ` --out=${outPath}`;
 
-    let command = `mongoexport${uri}${host}${port}${username}${password}${db}${collection}${ssl}${sslCAFile}${sslPEMKeyFile}${sslPEMKeyPassword}${sslCRLFile}${sslAllowInvalidCertificates}${sslAllowInvalidHostnames}${sslFIPSMode}${authenticationMechanism}${gssapiServiceName}${gssapiHostName}${authenticationDatabase}${readPreference}${verbose}${quiet}${ipv6}${fields}${fieldFile}${query}${type}${jsonFormat}${jsonArray}${pretty}${noHeaderLine}${slaveOk}${dbpath}${directoryperdb}${forceTableScan}${skip}${limit}${sort}${out}`;
+    let command = `${method}${uri}${host}${port}${username}${password}${db}${collection}${ssl}${sslCAFile}${sslPEMKeyFile}${sslPEMKeyPassword}${sslCRLFile}${sslAllowInvalidCertificates}${sslAllowInvalidHostnames}${sslFIPSMode}${authenticationMechanism}${gssapiServiceName}${gssapiHostName}${authenticationDatabase}${readPreference}${verbose}${quiet}${ipv6}${fields}${fieldFile}${query}${type}${jsonFormat}${jsonArray}${pretty}${noHeaderLine}${slaveOk}${dbpath}${directoryperdb}${forceTableScan}${skip}${limit}${sort}${out}`;
     return command;
 }

--- a/source/utils/options/defaultOptions.ts
+++ b/source/utils/options/defaultOptions.ts
@@ -6,6 +6,7 @@ import {
     LogOptions,
     OutOptions
 } from '@/interfaces/options';
+import { ConfigOptions } from '@/interfaces/options/configOptions';
 
 const DEFAULT_CONNECTION_OPTIONS: ConnectionOptions = {
     uri: undefined,
@@ -77,10 +78,15 @@ const DEFAULT_OUT_OPTIONS: OutOptions = {
     detailedResult: false
 };
 
+const DEFAULT_CONFIG_OPTIONS: ConfigOptions = {
+    method: 'mongoexport'
+};
+
 export const DEFAULT_OPTIONS: Options = {
     ...DEFAULT_CONNECTION_OPTIONS,
     ...DEFAULT_EXPORTING_OPTIONS,
     ...DEFAULT_EXPORTED_OPTIONS,
     ...DEFAULT_LOG_OPTIONS,
-    ...DEFAULT_OUT_OPTIONS
+    ...DEFAULT_OUT_OPTIONS,
+    ...DEFAULT_CONFIG_OPTIONS
 };

--- a/test/getCommand/getCommand.test.ts
+++ b/test/getCommand/getCommand.test.ts
@@ -15,7 +15,7 @@ export default function (): void {
             };
             const outPath = './exported';
 
-            const expected = 'mongoexport --uri=mongodb://localhost:27017/cars --collection=Ferrari --out=./exported';
+            const expected = 'mongoexport --uri="mongodb://localhost:27017/cars" --collection=Ferrari --out=./exported';
             const result = getCommand(database, collection, options, outPath);
             expect(result).to.equal(expected);
         });
@@ -30,7 +30,7 @@ export default function (): void {
             };
             const outPath = './exported';
 
-            const expected = 'mongoexport --uri=mongodb://localhost:27017/cars --collection=Ferrari --out=./exported';
+            const expected = 'mongoexport --uri="mongodb://localhost:27017/cars" --collection=Ferrari --out=./exported';
             const result = getCommand(database, collection, options, outPath);
             expect(result).to.equal(expected);
         });
@@ -46,7 +46,24 @@ export default function (): void {
             const outPath = './exported';
 
             const expected =
-                'mongoexport --uri=mongodb://localhost:27017/cars?connectTimeoutMS=300000 --collection=Ferrari --out=./exported';
+                'mongoexport --uri="mongodb://localhost:27017/cars?connectTimeoutMS=300000" --collection=Ferrari --out=./exported';
+            const result = getCommand(database, collection, options, outPath);
+            expect(result).to.equal(expected);
+        });
+
+        it(`Should return a command with a correctly parsed uri with additional parameters and slash paths`, function () {
+            const database = 'cars';
+            const collection: ExportingCollection = {
+                name: 'Ferrari'
+            };
+            const options: ConnectionOptions = {
+                uri:
+                    'mongodb://localhost:27017/computers?connectTimeoutMS=300000&authSource=admin&tls=true&tlsCAFile=./secret/ca.txt'
+            };
+            const outPath = './exported';
+
+            const expected =
+                'mongoexport --uri="mongodb://localhost:27017/cars?connectTimeoutMS=300000&authSource=admin&tls=true&tlsCAFile=./secret/ca.txt" --collection=Ferrari --out=./exported';
             const result = getCommand(database, collection, options, outPath);
             expect(result).to.equal(expected);
         });

--- a/test/getMongoConnection/getMongoConnection.test.ts
+++ b/test/getMongoConnection/getMongoConnection.test.ts
@@ -134,5 +134,29 @@ export default function (): void {
             const result = await getMongoConnectionFromOptions(options);
             expect(result.uri).to.equal(expected);
         });
+
+        it(`Should return a uri and correct ssl configuration`, async function () {
+            const options: ConnectionOptions = {
+                host: 'localhost',
+                port: 27017,
+                authenticationDatabase: 'users',
+                authenticationMechanism: AuthenticationMechanism.PLAIN,
+                ssl: true,
+                sslCAFile: './cert/ca.pem',
+                sslAllowInvalidCertificates: true,
+                sslAllowInvalidHostnames: true
+            };
+
+            const expected = 'mongodb://localhost:27017/?authSource=users&authMechanism=PLAIN';
+            const expectedOptions = {
+                ssl: true,
+                tlsAllowInvalidCertificates: true,
+                tlsAllowInvalidHostnames: true,
+                tlsCAFile: './cert/ca.pem'
+            };
+            const result = await getMongoConnectionFromOptions(options);
+            expect(result.uri).to.equal(expected);
+            expect(result.options).to.deep.equal(expectedOptions);
+        });
     });
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -85,6 +85,12 @@ const libConfig = {
             commonjs: '../utils/utils',
             commonjs2: '../utils/utils'
         },
+        '@/utils/checkMongodumpInstalled': {
+            amd: '../utils/utils',
+            root: 'mongoback',
+            commonjs: '../utils/utils',
+            commonjs2: '../utils/utils'
+        },
         '@/utils/logger': {
             amd: '../utils/utils',
             root: 'mongoback',
@@ -162,6 +168,12 @@ const binConfig = {
     },
     externals: [{
         '@/utils/checkMongoexportInstalled': {
+            amd: '../utils/utils',
+            root: 'mongoback',
+            commonjs: '../utils/utils',
+            commonjs2: '../utils/utils'
+        },
+        '@/utils/checkMongodumpInstalled': {
             amd: '../utils/utils',
             root: 'mongoback',
             commonjs: '../utils/utils',


### PR DESCRIPTION
Added the ability to define a "method" configuration option, which is by default "mongoexport", but you can specify "mongodump" to use mongodump method instead. I followed the same pattern of your code more or less, but please excuse if I have missed anything.

I have made the necessary changes on the CLI method as well.

However, what I didn't have enough time to do was adding tests.
Even though I ran tests to make sure everything works as usual and nothing breaks because of this change.
Also, I didn't run the "docs:tree" because it was generating a lot of other extra things in the tree like documentations and licenses which I don't have much knowledge about. I'll leave this to you.

Let me know if there's something which I can help with.

To use the new ability,
simply add a 
`method: "mongodump"` to the main configuration when calling `mongoExport`.

I really love the tool, and all the powerful configurations it supports. Having the ability of "mongodump" would be cherry on the cake.